### PR TITLE
Ensure the daemonset is in the openshift-monitoring namespace

### DIFF
--- a/process-exporter/daemonset.yaml
+++ b/process-exporter/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: process-exporter
+  namespace: openshift-monitoring
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Without this, the daemonset couldn't find the serviceaccount it needed:

```
  Warning  FailedCreate  69s (x15 over 2m31s)  daemonset-controller  Error creating: pods "process-exporter-" is forbidden: error looking up service account default/node-exporter: serviceaccount "node-exporter" not found
```